### PR TITLE
Use sampling rate after resampling in peak extraction

### DIFF
--- a/src/tempbeat/extraction/heartbeat_extraction.py
+++ b/src/tempbeat/extraction/heartbeat_extraction.py
@@ -172,7 +172,7 @@ def temp_hb_extract(
     ) = _temp_hb_extract_extract_potential_peaks_from_correlation(
         corrs,
         corr_times,
-        sampling_rate,
+        new_sampling_rate,
         corr_peak_extraction_method,
         fix_corr_peaks_by_height,
         fixpeaks_by_height_time_boundaries,

--- a/tests/extraction/test_heartbeat_extraction.py
+++ b/tests/extraction/test_heartbeat_extraction.py
@@ -20,35 +20,36 @@ class TestTempHbExtract:
         The function should extract the peak times such that they are within 0.01 seconds of the expected values.
         The expected values were obtained by running the function on the example ECG data with the same parameters.
         """
-        sampling_rate = 100
-        data = nk.data("bio_resting_5min_100hz")
-        sig = data["ECG"]
+        sampling_rate = 200
+        data = nk.data("bio_resting_8min_200hz")
+        sig = data["S01"]["ECG"]
         sig_time = sampling_rate_to_sig_time(sig, sampling_rate)
         peaks = temp_hb_extract(sig, sig_time=sig_time, sampling_rate=sampling_rate)
+
         np.testing.assert_allclose(
             peaks[:20],
             np.array(
                 [
-                    1.66,
-                    2.27,
-                    2.86,
-                    3.47,
-                    4.11,
-                    4.77,
-                    5.44,
-                    6.13,
-                    6.85,
-                    7.49,
-                    8.13,
-                    8.79,
-                    9.47,
-                    10.12,
-                    10.75,
-                    11.4,
-                    12.08,
-                    12.77,
-                    13.41,
-                    14.04,
+                    8.55,
+                    9.36,
+                    10.24,
+                    11.09,
+                    11.91,
+                    12.71,
+                    13.47,
+                    14.32,
+                    15.115,
+                    15.91,
+                    16.695,
+                    17.48,
+                    18.26,
+                    19.02,
+                    19.87,
+                    20.73,
+                    21.49,
+                    22.26,
+                    23.1,
+                    23.99,
                 ]
             ),
             rtol=0.01,


### PR DESCRIPTION
I think I accidentally used the incorrect sampling rate in one of the functions within the template algorithm: https://github.com/danibene/tempbeat/issues/11 